### PR TITLE
Enhancement: Implement log entry parser

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,8 @@
     }
   ],
   "require": {
-    "php": "^7.2"
+    "php": "^7.2",
+    "kassner/log-parser": "^1.4.0"
   },
   "require-dev": {
     "infection/infection": "~0.9.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,62 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "bb23ec5358fcb44913f8ef075b2c64be",
-    "packages": [],
+    "content-hash": "4a71c7a9d107152b3c30d9d0b0842921",
+    "packages": [
+        {
+            "name": "kassner/log-parser",
+            "version": "1.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/kassner/log-parser.git",
+                "reference": "1250b60de8175d0477987cd7a2d27b695896dc20"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/kassner/log-parser/zipball/1250b60de8175d0477987cd7a2d27b695896dc20",
+                "reference": "1250b60de8175d0477987cd7a2d27b695896dc20",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.4"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^2.11",
+                "phpmd/phpmd": "~2.1",
+                "phpunit/phpunit": "~4.4",
+                "sebastian/phpcpd": "~2.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "Kassner": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache 2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Rafael Kassner",
+                    "email": "kassner@gmail.com",
+                    "homepage": "http://www.kassner.com.br/",
+                    "role": "Developer"
+                }
+            ],
+            "description": "PHP Log Parser Library",
+            "homepage": "http://github.com/kassner/log-parser",
+            "keywords": [
+                "apache",
+                "format",
+                "log",
+                "log-format",
+                "nginx",
+                "parser"
+            ],
+            "time": "2018-03-21T13:49:33+00:00"
+        }
+    ],
     "packages-dev": [
         {
             "name": "composer/ca-bundle",

--- a/src/EntryParser.php
+++ b/src/EntryParser.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2018 Andreas Möller.
+ *
+ * @see https://github.com/localheinz/http-log
+ */
+
+namespace Localheinz\Http\Log;
+
+use Kassner\LogParser;
+
+final class EntryParser implements EntryParserInterface
+{
+    private const FORMAT = '%h %l %u %t "%m %U %H" %>s %b';
+
+    /**
+     * @var LogParser\LogParser
+     */
+    private $logParser;
+
+    public function __construct(LogParser\LogParser $logParser = null)
+    {
+        $this->logParser = $logParser ?: new LogParser\LogParser();
+        $this->logParser->setFormat(self::FORMAT);
+    }
+
+    public function parse(string $line): \stdClass
+    {
+        try {
+            $parsed = $this->logParser->parse($line);
+        } catch (LogParser\FormatException $exception) {
+            throw Exception\UnableToParseEntryException::fromLineAndPattern(
+                $line,
+                $this->logParser->getPCRE()
+            );
+        }
+
+        return $parsed;
+    }
+}

--- a/src/EntryParserInterface.php
+++ b/src/EntryParserInterface.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2018 Andreas Möller.
+ *
+ * @see https://github.com/localheinz/http-log
+ */
+
+namespace Localheinz\Http\Log;
+
+interface EntryParserInterface
+{
+    /**
+     * @param string $line
+     *
+     * @throws Exception\UnableToParseEntryException
+     *
+     * @return \stdClass
+     */
+    public function parse(string $line): \stdClass;
+}

--- a/src/Exception/UnableToParseEntryException.php
+++ b/src/Exception/UnableToParseEntryException.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2018 Andreas Möller.
+ *
+ * @see https://github.com/localheinz/http-log
+ */
+
+namespace Localheinz\Http\Log\Exception;
+
+final class UnableToParseEntryException extends \InvalidArgumentException
+{
+    public static function fromLineAndPattern(string $line, string $pattern): self
+    {
+        return new self(\sprintf(
+            'Unable to parse log line "%s", it does not match the pattern "%s".',
+            $line,
+            $pattern
+        ));
+    }
+}

--- a/test/Unit/EntryParserTest.php
+++ b/test/Unit/EntryParserTest.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2018 Andreas Möller.
+ *
+ * @see https://github.com/localheinz/http-log
+ */
+
+namespace Localheinz\Http\Log\Test\Unit;
+
+use Kassner\LogParser;
+use Localheinz\Http\Log\EntryParser;
+use Localheinz\Http\Log\EntryParserInterface;
+use Localheinz\Http\Log\Exception;
+use Localheinz\Test\Util\Helper;
+use PHPUnit\Framework;
+use Prophecy\Argument;
+
+/**
+ * @internal
+ */
+final class EntryParserTest extends Framework\TestCase
+{
+    use Helper;
+
+    public function testImplementsEntryParserInterface(): void
+    {
+        $this->assertClassImplementsInterface(EntryParserInterface::class, EntryParser::class);
+    }
+
+    public function testConstructorSetsPattern(): void
+    {
+        $logParser = $this->prophesize(LogParser\LogParser::class);
+
+        $logParser
+            ->setFormat(Argument::is('%h %l %u %t "%m %U %H" %>s %b'))
+            ->shouldBeCalled();
+
+        new EntryParser($logParser->reveal());
+    }
+
+    public function testParseThrowsUnableToParseExceptionWhenLineDoesNotMatch(): void
+    {
+        $faker = $this->faker();
+
+        $line = $faker->sentence;
+        $pattern = $faker->sentence;
+
+        $logParser = $this->prophesize(LogParser\LogParser::class);
+
+        $logParser
+            ->setFormat(Argument::type('string'))
+            ->shouldBeCalled();
+
+        $logParser
+            ->parse(Argument::is($line))
+            ->shouldBeCalled()
+            ->willThrow(new LogParser\FormatException());
+
+        $logParser
+            ->getPCRE()
+            ->shouldBeCalled()
+            ->willReturn($pattern);
+
+        $entryParser = new EntryParser($logParser->reveal());
+
+        $this->expectException(Exception\UnableToParseEntryException::class);
+
+        $entryParser->parse($line);
+    }
+
+    public function testParseReturnsParsedLogEntry(): void
+    {
+        $line = $this->faker()->sentence;
+        $parsed = new \stdClass();
+
+        $logParser = $this->prophesize(LogParser\LogParser::class);
+
+        $logParser
+            ->setFormat(Argument::type('string'))
+            ->shouldBeCalled();
+
+        $logParser
+            ->parse(Argument::is($line))
+            ->shouldBeCalled()
+            ->willReturn($parsed);
+
+        $entryParser = new EntryParser($logParser->reveal());
+
+        $this->assertSame($parsed, $entryParser->parse($line));
+    }
+}

--- a/test/Unit/Exception/UnableToParseEntryExceptionTest.php
+++ b/test/Unit/Exception/UnableToParseEntryExceptionTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2018 Andreas Möller.
+ *
+ * @see https://github.com/localheinz/http-log
+ */
+
+namespace Localheinz\Http\Log\Test\Unit\Exception;
+
+use Localheinz\Http\Log\Exception\UnableToParseEntryException;
+use Localheinz\Test\Util\Helper;
+use PHPUnit\Framework;
+
+/**
+ * @internal
+ */
+final class UnableToParseEntryExceptionTest extends Framework\TestCase
+{
+    use Helper;
+
+    public function testExtendsInvalidArgumentException(): void
+    {
+        $this->assertClassExtends(\InvalidArgumentException::class, UnableToParseEntryException::class);
+    }
+
+    public function testFromLineAndPatternCreatesException(): void
+    {
+        $faker = $this->faker();
+
+        $line = $faker->sentence;
+        $pattern = $faker->sentence;
+
+        $exception = UnableToParseEntryException::fromLineAndPattern(
+            $line,
+            $pattern
+        );
+
+        $this->assertInstanceOf(UnableToParseEntryException::class, $exception);
+
+        $expected = \sprintf(
+            'Unable to parse log line "%s", it does not match the pattern "%s".',
+            $line,
+            $pattern
+        );
+
+        $this->assertSame($expected, $exception->getMessage());
+    }
+}


### PR DESCRIPTION
This PR

* [x] requires `kassner/log-parser`
* [x] implements an entry parser that functions as a wrapper around `Kassner\LogParser\LogParser`

💁‍♂️ For reference, see https://github.com/kassner/log-parser.