### PR TITLE
Enhancement: Implement expiring log

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,8 @@
   ],
   "require": {
     "php": "^7.2",
-    "kassner/log-parser": "^1.4.0"
+    "kassner/log-parser": "^1.4.0",
+    "localheinz/clock": "^1.0.0"
   },
   "require-dev": {
     "infection/infection": "~0.9.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4a71c7a9d107152b3c30d9d0b0842921",
+    "content-hash": "24c22abb9ca8d99eb841688586767527",
     "packages": [
         {
             "name": "kassner/log-parser",
@@ -58,6 +58,55 @@
                 "parser"
             ],
             "time": "2018-03-21T13:49:33+00:00"
+        },
+        {
+            "name": "localheinz/clock",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/localheinz/clock.git",
+                "reference": "d558b89fde2025271b0cd99884867418a4030b60"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/localheinz/clock/zipball/d558b89fde2025271b0cd99884867418a4030b60",
+                "reference": "d558b89fde2025271b0cd99884867418a4030b60",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0"
+            },
+            "require-dev": {
+                "infection/infection": "~0.7.0",
+                "localheinz/php-cs-fixer-config": "~1.11.0",
+                "localheinz/test-util": "0.6.1",
+                "phpstan/phpstan": "~0.9.1",
+                "phpunit/phpunit": "^6.5.5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Localheinz\\Clock\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Andreas Möller",
+                    "email": "am@localheinz.com"
+                }
+            ],
+            "description": "Provides a simple abstraction of a clock.",
+            "homepage": "https://github.com/localheinz/clock",
+            "keywords": [
+                "clock",
+                "system-clock",
+                "test-clock"
+            ],
+            "time": "2018-01-30T23:25:04+00:00"
         }
     ],
     "packages-dev": [

--- a/src/ExpiringLog.php
+++ b/src/ExpiringLog.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2018 Andreas Möller.
+ *
+ * @see https://github.com/localheinz/http-log
+ */
+
+namespace Localheinz\Http\Log;
+
+use Localheinz\Clock;
+
+final class ExpiringLog implements LogInterface
+{
+    private const MAX_AGE_DEFAULT = 10;
+    private const MAX_AGE_MIN = 0;
+
+    /**
+     * @var int
+     */
+    private $maxAgeInSeconds;
+
+    /**
+     * @var Clock\ClockInterface
+     */
+    private $clock;
+
+    /**
+     * @var EntryInterface[]
+     */
+    private $entries = [];
+
+    /**
+     * @param int                       $maxAgeInSeconds
+     * @param null|Clock\ClockInterface $clock
+     *
+     * @throws \InvalidArgumentException
+     */
+    public function __construct(int $maxAgeInSeconds = self::MAX_AGE_DEFAULT, Clock\ClockInterface $clock = null)
+    {
+        if (self::MAX_AGE_MIN >= $maxAgeInSeconds) {
+            throw new \InvalidArgumentException(\sprintf(
+                'Max age needs to be greater than %d, but %d is not.',
+                self::MAX_AGE_MIN,
+                $maxAgeInSeconds
+            ));
+        }
+
+        $this->maxAgeInSeconds = $maxAgeInSeconds;
+        $this->clock = $clock ?: new Clock\SystemClock();
+    }
+
+    public function log(EntryInterface $entry): void
+    {
+        $this->entries[] = $entry;
+    }
+
+    public function entries(): array
+    {
+        $this->removeExpiredEntries();
+
+        return $this->entries;
+    }
+
+    private function removeExpiredEntries(): void
+    {
+        $now = $this->clock->now();
+
+        $expirationTime = $now->sub(new \DateInterval(\sprintf(
+            'PT%dS',
+            $this->maxAgeInSeconds
+        )));
+
+        $this->entries = \array_filter($this->entries, function (EntryInterface $entry) use ($expirationTime) {
+            return $entry->requestTime() > $expirationTime;
+        });
+    }
+}

--- a/src/LogInterface.php
+++ b/src/LogInterface.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2018 Andreas Möller.
+ *
+ * @see https://github.com/localheinz/http-log
+ */
+
+namespace Localheinz\Http\Log;
+
+interface LogInterface
+{
+    /**
+     * Logs an entry.
+     *
+     * @param EntryInterface $entry
+     */
+    public function log(EntryInterface $entry): void;
+
+    /**
+     * Returns all entries currently stored in the log.
+     *
+     * @return EntryInterface[]
+     */
+    public function entries(): array;
+}

--- a/test/Unit/ExpiringLogTest.php
+++ b/test/Unit/ExpiringLogTest.php
@@ -1,0 +1,134 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2018 Andreas Möller.
+ *
+ * @see https://github.com/localheinz/http-log
+ */
+
+namespace Localheinz\Http\Log\Test\Unit;
+
+use Localheinz\Clock;
+use Localheinz\Http\Log\EntryInterface;
+use Localheinz\Http\Log\ExpiringLog;
+use Localheinz\Test\Util\Helper;
+use PHPUnit\Framework;
+
+/**
+ * @internal
+ */
+final class ExpiringLogTest extends Framework\TestCase
+{
+    use Helper;
+
+    public function testDefaults(): void
+    {
+        $log = new ExpiringLog();
+
+        $this->assertEmpty($log->entries());
+    }
+
+    /**
+     * @dataProvider providerInvalidMaxAgeInSeconds
+     *
+     * @param int $maxAgeInSeconds
+     */
+    public function testConstructorRejectsInvalidMaxAgeInSeconds(int $maxAgeInSeconds): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage(\sprintf(
+            'Max age needs to be greater than 0, but %d is not.',
+            $maxAgeInSeconds
+        ));
+
+        new ExpiringLog($maxAgeInSeconds);
+    }
+
+    public function providerInvalidMaxAgeInSeconds(): \Generator
+    {
+        $values = [
+            'int-zero' => 0,
+            'int-below-zero' => -1 * $this->faker()->numberBetween(1),
+        ];
+
+        foreach ($values as $key => $value) {
+            yield $key => [
+                $value,
+            ];
+        }
+    }
+
+    public function testEntriesDoesNotReturnExpiredEntries(): void
+    {
+        $faker = $this->faker();
+
+        $maxAgeInSeconds = $faker->numberBetween(
+            5,
+            3600
+        );
+
+        $now = new \DateTimeImmutable();
+
+        $expiredEntry = $this->prophesize(EntryInterface::class);
+
+        $expiredEntry
+            ->requestTime()
+            ->shouldBeCalled()
+            ->willReturn($now->sub(new \DateInterval(\sprintf(
+                'PT%dS',
+                $faker->numberBetween(
+                    $maxAgeInSeconds + 1,
+                    $maxAgeInSeconds + 100
+                )
+            ))));
+
+        $clock = new Clock\FrozenClock($now);
+
+        $log = new ExpiringLog(
+            $maxAgeInSeconds,
+            $clock
+        );
+
+        $log->log($expiredEntry->reveal());
+
+        $this->assertEmpty($log->entries());
+    }
+
+    public function testEntriesReturnsNonExpiredEntries(): void
+    {
+        $faker = $this->faker();
+
+        $maxAgeInSeconds = $faker->numberBetween(
+            5,
+            3600
+        );
+
+        $now = new \DateTimeImmutable();
+
+        $nonExpiredEntry = $this->prophesize(EntryInterface::class);
+
+        $nonExpiredEntry
+            ->requestTime()
+            ->shouldBeCalled()
+            ->willReturn($now->sub(new \DateInterval(\sprintf(
+                'PT%dS',
+                $faker->numberBetween(
+                    0,
+                    $maxAgeInSeconds - 1
+                )
+            ))));
+
+        $clock = new Clock\FrozenClock($now);
+
+        $log = new ExpiringLog(
+            $maxAgeInSeconds,
+            $clock
+        );
+
+        $log->log($nonExpiredEntry->reveal());
+
+        $this->assertContains($nonExpiredEntry->reveal(), $log->entries());
+    }
+}


### PR DESCRIPTION
This PR

* [x] requires `localheinz/clock`
* [ ] implements an expiring log

💁‍♂️ For reference, see https://github.com/localheinz/clock.
