### PR TITLE
Enhancement: Allow construction without specifying hits

### DIFF
--- a/src/SectionHits.php
+++ b/src/SectionHits.php
@@ -28,7 +28,7 @@ final class SectionHits implements SectionHitsInterface
      *
      * @throws \InvalidArgumentException
      */
-    public function __construct(SectionInterface $section, int $hits)
+    public function __construct(SectionInterface $section, int $hits = 1)
     {
         if (0 > $hits) {
             throw new \InvalidArgumentException(\sprintf(

--- a/test/Unit/SectionHitsTest.php
+++ b/test/Unit/SectionHitsTest.php
@@ -28,6 +28,16 @@ final class SectionHitsTest extends Framework\TestCase
         $this->assertClassImplementsInterface(SectionHitsInterface::class, SectionHits::class);
     }
 
+    public function testDefaults(): void
+    {
+        $section = $this->prophesize(SectionInterface::class);
+
+        $sectionHits = new SectionHits($section->reveal());
+
+        $this->assertSame($section->reveal(), $sectionHits->section());
+        $this->assertSame(1, $sectionHits->hits());
+    }
+
     /**
      * @dataProvider providerInvalidHits
      *


### PR DESCRIPTION
This PR

* [x] allows construction of `SectionHits` without specifying `$hits`

Follows #6.