### PR TITLE
Fix: Ensure that requests per seconds honors oldest request time

### DIFF
--- a/src/Analyzer.php
+++ b/src/Analyzer.php
@@ -72,7 +72,19 @@ final class Analyzer implements AnalyzerInterface
             return $entry->requestTime() >= $since;
         });
 
-        $seconds = $now->getTimestamp() - $since->getTimestamp();
+        if (0 === \count($requests)) {
+            return 0.0;
+        }
+
+        /** @var EntryInterface $oldestRequest */
+        $oldestRequest = \reset($requests);
+
+        $oldestTimestamp = \max(
+            $oldestRequest->requestTime()->getTimestamp(),
+            $since->getTimestamp()
+        );
+
+        $seconds = $now->getTimestamp() - $oldestTimestamp;
 
         return \count($requests) / $seconds;
     }


### PR DESCRIPTION
This PR

* [x] asserts that seconds used for calculating requests per second honors oldest request
* [x] ensures that when oldest request is younger than since, it's request time is used to calculate time span

Follows #11.